### PR TITLE
Add `tests/data` folder and exclude it from pre-commit

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
-repos:
+exclude: tests/TESTDATA
+repo:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
   hooks:

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: tests/TESTDATA
+exclude: tests/TESTDATA/
 repo:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: tests/TESTDATA/
+exclude: tests/data/
 repo:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0


### PR DESCRIPTION
This PR adds an empty `tests/data` folder, which is excluded from all `pre-commit` hooks.
Note that also the `check-added-large-files` hook does not check `data`. Thoughts?