### PR TITLE
Use default cache key

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -47,7 +47,6 @@ jobs:
         environment-name: DEVELOP
         channels: conda-forge
         cache-env: true
-        cache-env-key: ubuntu-latest-3.10
         extra-specs: |
           python=3.10
     - name: Test my-package

--- a/{{cookiecutter.project_name}}/.github/workflows/on-push.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/on-push.yml
@@ -101,8 +101,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: '3.10'
-            extra: -minver
+        - python-version: '3.10'
+          extra: -minver
 
     steps:
     - uses: actions/checkout@v3

--- a/{{cookiecutter.project_name}}/.github/workflows/on-push.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/on-push.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ '{{ github.workflow }}' }}-${{ '{{ github.ref }}' }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
@@ -27,9 +31,6 @@ jobs:
   unit-tests:
     name: unit-tests (3.10)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
     - uses: actions/checkout@v3
@@ -40,7 +41,6 @@ jobs:
         environment-name: DEVELOP
         channels: conda-forge
         cache-env: true
-        cache-env-key: ubuntu-latest-3.10
         extra-specs: |
           python=3.10
     - name: Install package
@@ -53,9 +53,6 @@ jobs:
   type-check:
     needs: [unit-tests]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
     - uses: actions/checkout@v3
@@ -66,7 +63,6 @@ jobs:
         environment-name: DEVELOP
         channels: conda-forge
         cache-env: true
-        cache-env-key: ubuntu-latest-3.10
         extra-specs: |
           python=3.10
     - name: Install package
@@ -79,9 +75,6 @@ jobs:
   documentation:
     needs: [unit-tests]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
 
     steps:
     - uses: actions/checkout@v3
@@ -92,7 +85,6 @@ jobs:
         environment-name: DEVELOP
         channels: conda-forge
         cache-env: true
-        cache-env-key: ubuntu-latest-3.10
         extra-specs: |
           python=3.10
     - name: Install package
@@ -105,15 +97,12 @@ jobs:
   integration-tests:
     needs: [unit-tests]
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
 
     strategy:
       matrix:
         include:
-        - python-version: '3.10'
-          extra: -minver
+          - python-version: '3.10'
+            extra: -minver
 
     steps:
     - uses: actions/checkout@v3
@@ -124,7 +113,6 @@ jobs:
         environment-name: DEVELOP${{ '{{ matrix.extra }}' }}
         channels: conda-forge
         cache-env: true
-        cache-env-key: ubuntu-latest-${{ '{{ matrix.python-version }}' }}${{ '{{ matrix.extra }}' }}.
         extra-specs: |
           python=${{ '{{matrix.python-version }}' }}
     - name: Install package


### PR DESCRIPTION
It's better to use the default invalidation key of the mambaforge action.

> With the default environment cache key, separate caches will be created for each operating system (eg., Linux) and platform (eg., x64) and day (eg., 2022-01-31), and the cache will be invalidated whenever the contents of 'environment-file' or 'extra-specs' change.

We used to do pretty much the same, but without the day, which means that we will eventually use very old environments.