### PR TITLE
Avoids conflicts with check-yaml when semicolons are present.

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
   rev: v2.4.0
   hooks:
   - id: pretty-format-yaml
-    args: [--autofix]
+    args: [--autofix, --preserve-quotes]
   - id: pretty-format-toml
     args: [--autofix]
 - repo: https://github.com/PyCQA/pydocstyle.git


### PR DESCRIPTION
This is needed for this line to pass pre-commit 

```
    healthcheck:
      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
```