### PR TITLE
add PAT

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/on-push.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/on-push.yml
@@ -18,6 +18,9 @@ defaults:
   run:
     shell: bash -l {0}
 
+env:
+  PAT_GITHUB: ${{ '{{ secrets.PAT_GITHUB }}' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub does not allow to use the same deploy keys for multiple repositories. Therefore, we can't use deploy keys.
I suggest to just use PAT + pip installation of git repos.

Workflow for users that need to install private repos:
1. Create a GitHub PAT
2. Add a repository secret named `PAT_GITHUB`
3. In the `ci/environment-ci.yml`, add private repo as follow:
```
- pip:
  - git+https://${PAT_GITHUB}@github.com/ecmwf-projects/name-of-repo.git
```